### PR TITLE
feat: add tags support and enhance post hero with badges and last edi…

### DIFF
--- a/src/blocks/Code/Component.client.tsx
+++ b/src/blocks/Code/Component.client.tsx
@@ -61,10 +61,12 @@ export const Code: React.FC<Props> = ({ code, language = '' }) => {
               {language}
             </div>
           )}
-          <pre className="font-mono text-xs overflow-x-auto pl-1 pr-4 py-4">
+          <pre className="font-mono text-xs overflow-x-auto relative py-4">
+            {/* Full-height border positioned relative to pre */}
+            <div className="absolute top-0 bottom-0 left-[2.5rem] w-px bg-[#d0d7de] dark:bg-[#30363d] pointer-events-none"></div>
             <div className="flex">
-              {/* Line numbers column */}
-              <div className="flex-shrink-0 w-10 pr-2 text-right select-none text-[#8c959f] dark:text-[#6e7681] border-r border-[#d0d7de] dark:border-[#30363d] mr-4">
+              {/* Line numbers column with darker background */}
+              <div className="flex-shrink-0 w-10 text-center select-none text-[#8c959f] dark:text-[#6e7681] bg-[#f0f2f5] dark:bg-[#0d1117] mr-4 -my-4 py-4">
                 {tokens.map((_, i) => (
                   <div key={i} className="leading-6">
                     {i + 1}
@@ -72,7 +74,7 @@ export const Code: React.FC<Props> = ({ code, language = '' }) => {
                 ))}
               </div>
               {/* Code content column */}
-              <div className="flex-1 min-w-0">
+              <div className="flex-1 min-w-0 pr-4">
                 {tokens.map((line, i) => (
                   <div key={i} {...getLineProps({ line })} className="leading-6">
                     {line.map((token, key) => (

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -42,6 +42,7 @@ export const Posts: CollectionConfig<'posts'> = {
     title: true,
     slug: true,
     categories: true,
+    tags: true,
     meta: {
       image: true,
       description: true,
@@ -129,6 +130,15 @@ export const Posts: CollectionConfig<'posts'> = {
               hasMany: true,
               relationTo: 'categories',
             },
+            {
+              name: 'tags',
+              type: 'relationship',
+              admin: {
+                position: 'sidebar',
+              },
+              hasMany: true,
+              relationTo: 'tags',
+            },
           ],
           label: 'Meta',
         },
@@ -179,6 +189,17 @@ export const Posts: CollectionConfig<'posts'> = {
             return value
           },
         ],
+      },
+    },
+    {
+      name: 'lastEdited',
+      type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'dayAndTime',
+        },
+        position: 'sidebar',
+        description: 'Date when the post was last edited. Leave empty if not edited after publication.',
       },
     },
     {

--- a/src/collections/Tags.ts
+++ b/src/collections/Tags.ts
@@ -1,0 +1,28 @@
+import type { CollectionConfig } from 'payload'
+
+import { anyone } from '../access/anyone'
+import { authenticated } from '../access/authenticated'
+import { slugField } from 'payload'
+
+export const Tags: CollectionConfig = {
+  slug: 'tags',
+  access: {
+    create: authenticated,
+    delete: authenticated,
+    read: anyone,
+    update: authenticated,
+  },
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    slugField({
+      position: undefined,
+    }),
+  ],
+}

--- a/src/heros/PostHero/index.tsx
+++ b/src/heros/PostHero/index.tsx
@@ -5,14 +5,21 @@ import type { Post } from '@/payload-types'
 
 import { Media } from '@/components/Media'
 import { formatAuthors } from '@/utilities/formatAuthors'
+import { Calendar, User, Hash, ArrowRight } from 'lucide-react'
+import { cn } from '@/utilities/ui'
 
 export const PostHero: React.FC<{
   post: Post
 }> = ({ post }) => {
-  const { categories, heroImage, populatedAuthors, publishedAt, title } = post
+  const { categories, heroImage, populatedAuthors, publishedAt, lastEdited, tags, title } = post
 
   const hasAuthors =
     populatedAuthors && populatedAuthors.length > 0 && formatAuthors(populatedAuthors) !== ''
+
+  const hasTags =
+    Array.isArray(tags) &&
+    tags.length > 0 &&
+    tags.some((tag) => typeof tag === 'object' && tag !== null)
 
   return (
     <div className="relative -mt-[10.4rem] flex items-end">
@@ -39,24 +46,58 @@ export const PostHero: React.FC<{
           </div>
 
           <div className="">
-            <h1 className="mb-6 text-3xl md:text-5xl lg:text-6xl">{title}</h1>
+            <h1 className="mb-6 text-4xl md:text-6xl lg:text-7xl xl:text-8xl">{title}</h1>
           </div>
 
-          <div className="flex flex-col md:flex-row gap-4 md:gap-16">
-            {hasAuthors && (
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1">
-                  <p className="text-sm">Author</p>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              {hasAuthors && (
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 backdrop-blur-sm px-3 py-1.5 text-sm',
+                  )}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  <span>{formatAuthors(populatedAuthors)}</span>
+                </span>
+              )}
+              {publishedAt && (
+                <span
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border border-white/20 bg-white/10 backdrop-blur-sm px-3 py-1.5 text-sm',
+                  )}
+                >
+                  <Calendar className="h-3.5 w-3.5" />
+                  <time dateTime={publishedAt}>{formatDateTime(publishedAt)}</time>
+                  {lastEdited && lastEdited !== publishedAt && (
+                    <>
+                      <ArrowRight className="h-3 w-3 mx-0.5" />
+                      <time dateTime={lastEdited}>{formatDateTime(lastEdited)}</time>
+                    </>
+                  )}
+                </span>
+              )}
+            </div>
 
-                  <p>{formatAuthors(populatedAuthors)}</p>
-                </div>
-              </div>
-            )}
-            {publishedAt && (
-              <div className="flex flex-col gap-1">
-                <p className="text-sm">Date Published</p>
-
-                <time dateTime={publishedAt}>{formatDateTime(publishedAt)}</time>
+            {hasTags && (
+              <div className="flex flex-wrap items-center gap-2">
+                {tags.map((tag) => {
+                  if (typeof tag === 'object' && tag !== null && 'title' in tag && tag.title) {
+                    const tagId = 'id' in tag ? tag.id : String(tag)
+                    return (
+                      <span
+                        key={tagId}
+                        className={cn(
+                          'inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 backdrop-blur-sm px-2.5 py-1 text-xs',
+                        )}
+                      >
+                        <Hash className="h-3 w-3" />
+                        <span>{tag.title}</span>
+                      </span>
+                    )
+                  }
+                  return null
+                })}
               </div>
             )}
           </div>

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -71,6 +71,7 @@ export interface Config {
     posts: Post;
     media: Media;
     categories: Category;
+    tags: Tag;
     users: User;
     redirects: Redirect;
     forms: Form;
@@ -93,6 +94,7 @@ export interface Config {
     posts: PostsSelect<false> | PostsSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
+    tags: TagsSelect<false> | TagsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
@@ -244,6 +246,7 @@ export interface Post {
   };
   relatedPosts?: (number | Post)[] | null;
   categories?: (number | Category)[] | null;
+  tags?: (number | Tag)[] | null;
   meta?: {
     title?: string | null;
     /**
@@ -253,6 +256,10 @@ export interface Post {
     description?: string | null;
   };
   publishedAt?: string | null;
+  /**
+   * Date when the post was last edited. Leave empty if not edited after publication.
+   */
+  lastEdited?: string | null;
   authors?: (number | User)[] | null;
   populatedAuthors?:
     | {
@@ -409,6 +416,21 @@ export interface Category {
         id?: string | null;
       }[]
     | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags".
+ */
+export interface Tag {
+  id: number;
+  title: string;
+  /**
+   * When enabled, the slug will auto-generate from the title field on save and autosave.
+   */
+  generateSlug?: boolean | null;
+  slug: string;
   updatedAt: string;
   createdAt: string;
 }
@@ -986,6 +1008,10 @@ export interface PayloadLockedDocument {
         value: number | Category;
       } | null)
     | ({
+        relationTo: 'tags';
+        value: number | Tag;
+      } | null)
+    | ({
         relationTo: 'users';
         value: number | User;
       } | null)
@@ -1196,6 +1222,7 @@ export interface PostsSelect<T extends boolean = true> {
   content?: T;
   relatedPosts?: T;
   categories?: T;
+  tags?: T;
   meta?:
     | T
     | {
@@ -1204,6 +1231,7 @@ export interface PostsSelect<T extends boolean = true> {
         description?: T;
       };
   publishedAt?: T;
+  lastEdited?: T;
   authors?: T;
   populatedAuthors?:
     | T
@@ -1328,6 +1356,17 @@ export interface CategoriesSelect<T extends boolean = true> {
         label?: T;
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "tags_select".
+ */
+export interface TagsSelect<T extends boolean = true> {
+  title?: T;
+  generateSlug?: T;
+  slug?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -8,6 +8,7 @@ import { Categories } from './collections/Categories'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
+import { Tags } from './collections/Tags'
 import { Users } from './collections/Users'
 import { Footer } from './Footer/config'
 import { Header } from './Header/config'
@@ -65,7 +66,7 @@ export default buildConfig({
       url: process.env.DATABASE_URL || '',
     },
   }),
-  collections: [Pages, Posts, Media, Categories, Users],
+  collections: [Pages, Posts, Media, Categories, Tags, Users],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
   plugins,


### PR DESCRIPTION
This PR adds tags support to blog posts and enhances the post hero component with improved visual design.

- Created Tags collection and added tags relationship field to Posts
- Added `lastEdited` date field to track post updates
- Display tags with hashtag icons in pill-shaped badges
- Show published date with arrow indicator (→) when post has been edited after publication
- Wrap all metadata elements (author, date, tags) in pill-shaped badges with semi-transparent backgrounds and backdrop blur
- Increase post title size across all breakpoints (text-4xl to text-8xl) for better visibility